### PR TITLE
ISPN-8479 Use SNAPSHOT builds for dev

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -40,9 +40,13 @@ modules:
       install:
           - name: datagrid
 artifacts:
-    - path: jboss-datagrid-7.2.0-server.zip
-      description: "Artifact is available on Customer Portal: https://access.redhat.com/jbossnetwork/restricted/softwareDetail.html?softwareId=50851&product=data.grid&version=&downloadType=distributions"
-      md5: 411376fedbd0df3ed373ae56e0a69c3c
+    # Uncomment this once we are at CR/Final phase
+    # - path: jboss-datagrid-7.2.0-server.zip
+    #   description: "Artifact is available on Customer Portal: https://access.redhat.com/jbossnetwork/restricted/softwareDetail.html?softwareId=50851&product=data.grid&version=&downloadType=distributions"
+    #   md5: 411376fedbd0df3ed373ae56e0a69c3c
+    - path: infinispan-server-8.5.0-redhat-SNAPSHOT-147-bin.zip
+      description: "Development artifact. Will be replaced by CR or Final version soon"
+      md5: e4913e57e6421da97bb7ad465e079786
 run:
       user: 185
       cmd:

--- a/modules/datagrid/install.sh
+++ b/modules/datagrid/install.sh
@@ -5,8 +5,21 @@ set -e
 SCRIPTS_DIR=/tmp/artifacts
 DISTRIBUTION_ZIP="jboss-datagrid-7.2.0-server.zip"
 DATAGRID_VERSION="7.2.0"
+DEV_SERVER_NAME='infinispan-server-8.5.*-redhat-SNAPSHOT'
+DEV_SERVER_NAME_ZIP="${DEV_SERVER_NAME}-*-bin.zip"
+
+# This executes only for dev builds. Once we start building CRs or Finals
+# we will be using $DISTRIBUTION_ZIP pattern
+if [ -f $SCRIPTS_DIR/$DEV_SERVER_NAME_ZIP ]; then
+  mv $SCRIPTS_DIR/$DEV_SERVER_NAME_ZIP $SCRIPTS_DIR/$DISTRIBUTION_ZIP
+fi
 
 unzip -q $SCRIPTS_DIR/$DISTRIBUTION_ZIP
+
+# This also executes only on dev builds.
+if [ -d $DEV_SERVER_NAME ]; then
+  mv $DEV_SERVER_NAME jboss-datagrid-$DATAGRID_VERSION-server
+fi
 mv jboss-datagrid-$DATAGRID_VERSION-server $JBOSS_HOME
 
 chown -R jboss:root $JBOSS_HOME


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-8479

This PR introduces a way to build JDG Online Service from a SNAPSHOT server build. The main motivation behind it is that there's too much delay in our JDG release cycle and we need a way to test newly introduced features for JDG Online Services.

Technically, the idea is to grab a raw build from Prod Jenkins installation. Since proper packaging happens a bit later in the Prod loop, so we need to adjust unpacking scripts to work with raw server path such as `infinispan-server-8.5.0-redhat-SNAPSHOT-15-bin.zip`. The rest of the process remains the same - you need to pass artifact url to the cacher and update build number (in this PR I used build `147`) along with MD5 checksum. After such PR gets in, you need to wait a little bit until OpenShift image gets rebuilt and use everything in JDG Online Services. It's semi-automatic but I would like it to stay this way (depending on SNAPSHOT and doing midnight rebuilds doesn't work well if something breaks at the last day of the sprint).

Please have a look at it @goldmann @ryanemerson @jsenko