### PR TITLE
Allow regular Docker builds (not only RH Docker variant)

### DIFF
--- a/overrides.yaml
+++ b/overrides.yaml
@@ -1,0 +1,1 @@
+from: "docker-registry.engineering.redhat.com/jboss/openjdk18-rhel7:1.1"


### PR DESCRIPTION
Add an ability to build an image with a regular/official Docker. datagrid71-dev branch only
